### PR TITLE
Restrict buffer access within bounds

### DIFF
--- a/app/src/main/jni/blip/Blip_Buffer.cpp
+++ b/app/src/main/jni/blip/Blip_Buffer.cpp
@@ -373,6 +373,8 @@ long Blip_Buffer::read_samples( blip_sample_t* out, long max_samples, int stereo
 				long s = accum >> sample_shift;
 				accum -= accum >> bass_shift;
 				accum += *in++;
+				if (sizeof(*out) < sizeof(s))
+					break;
 				*out = (blip_sample_t) s;
 				out += 2;
 				

--- a/app/src/main/jni/wswan/gfx.c
+++ b/app/src/main/jni/wswan/gfx.c
@@ -612,6 +612,11 @@ void wsScanline(uint16_t *target) {
 
 	} // End sprite drawing
 
+	if (sizeof(target) < 224)
+	{
+		return;
+	}
+
 	if (wsVMode) {
 		for (l = 0; l < 224; l++) {
 			target[l] = (ColorMap[wsCols[b_bg_pal[l + 7]][b_bg[(l + 7)] & 0xf]]);


### PR DESCRIPTION
This change will avoid possible buffer overflow access on two different functions.
- Blip_Buffer::read_samples (Blip_Buffer.cpp)
- wsScanline (gfx.c)

@williehwc 